### PR TITLE
Signal condition on empty selection

### DIFF
--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -166,6 +166,7 @@ vars_select <- function(.vars, ..., .include = character(), .exclude = character
 
   # Ensure all output .vars named
   if (is_empty(sel)) {
+    cnd_signal("tidyselect_empty", .mufflable = FALSE)
     names(sel) <- sel
   } else {
     unnamed <- names2(sel) == ""


### PR DESCRIPTION
Includes #12 

With this PR the `recipes` package can issue an error on empty selections.