### PR TITLE
Fix symbol scoping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,36 @@
+
+# tidyselect 0.0.0.9000
+
+tidyselect is the new home for the `select_vars()`, `rename_vars()`
+and `select_var()` functions. We took this opportunity to make a few
+adjustments to the API. The semantics of evaluation have changed:
+
+* Symbols are now evaluated in a data-only context that is isolated
+  from the calling environment. This means that you can no longer
+  refer to local variables unless you are explicitly unquoting these
+  variables with `!!`.
+
+  Note that since dplyr 0.7, helper calls (like `starts_with()`) obey
+  the opposite behaviour and are evaluated in the calling context
+  isolated from the data context. To sum up, symbols can only refer to
+  data frame objects, while helpers can only refer to contextual
+  objects. This differs from usual R evaluation semantics where both
+  the data and the calling environment are in scope (with the former
+  prevailing over the latter).
+
+
+There are a few cosmetic changes as well:
+
+* `select_vars()` and `rename_vars()` are now `vars_select()` and
+  `vars_rename()`. This follows the tidyverse convention that a prefix
+  corresponds to the input type while suffixes indicate the output
+  type. Similarly, `select_var()` is now `vars_pull()`.
+
+* The arguments are now prefixed with dots to limit argument matching
+  issues. While the dots help, it is still a good idea to splice a
+  list of captured quosures to make sure dotted arguments are never
+  matched to `vars_select()`'s named arguments:
+
+  ```
+  vars_select(vars, !!! quos(...))
+  ```

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,3 +11,8 @@ is_data_pronoun <- function(expr) {
 }
 
 commas <- function(...) paste0(..., collapse = ", ")
+
+paren_sym <- quote(`(`)
+minus_sym <- quote(`-`)
+colon_sym <- quote(`:`)
+c_sym <- quote(`c`)

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -151,25 +151,26 @@ vars_select <- function(.vars, ..., .include = character(), .exclude = character
   sel
 }
 
-syms_overscope <- function(vars) {
-  # The symbol overscope. Subsetting operators allow to subset the
-  # .data pronoun.
-  overscope_top <- child_env(NULL,
-    `$` = base::`$`,
-    `[[` = base::`[[`,
-    `-` = base::`-`,
-    `:` = base::`:`,
-    `(` = base::`(`,
-    c = base::c
-  )
+# The top of the symbol overscope contains the functions for datawise
+# operations. Subsetting operators allow to subset the .data pronoun.
+syms_overscope_top <- child_env(NULL,
+  `$` = base::`$`,
+  `[[` = base::`[[`,
+  `-` = base::`-`,
+  `:` = base::`:`,
+  `(` = base::`(`,
+  c = base::c
+)
+lockEnvironment(syms_overscope_top, bindings = TRUE)
 
+syms_overscope <- function(vars) {
   # Map variable names to their positions: this keeps integer semantics
   data <- set_names(as.list(seq_along(vars)), vars)
   data <- discard_unnamed(data)
 
-  overscope <- as_env(data, overscope_top)
+  overscope <- as_env(data, syms_overscope_top)
   overscope <- child_env(overscope, .data = data)
-  overscope <- new_overscope(overscope, overscope_top)
+  overscope <- new_overscope(overscope, syms_overscope_top)
 
   overscope
 }

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -115,6 +115,7 @@ vars_select <- function(.vars, ..., .include = character(), .exclude = character
   )
   # Map variable names to their positions: this keeps integer semantics
   syms_overscope_data <- set_names(as.list(seq_along(.vars)), .vars)
+  syms_overscope_data <- discard_unnamed(syms_overscope_data)
   syms_overscope <- as_env(syms_overscope_data, syms_overscope_top)
   syms_overscope <- child_env(syms_overscope, .data = syms_overscope_data)
   syms_overscope <- new_overscope(syms_overscope, syms_overscope_top)
@@ -162,6 +163,14 @@ vars_select <- function(.vars, ..., .include = character(), .exclude = character
   }
 
   sel
+}
+
+discard_unnamed <- function(x) {
+  if (is_env(x)) {
+    x
+  } else {
+    discard(x, names2(x) == "")
+  }
 }
 
 quo_is_helper <- function(quo) {

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -1,13 +1,19 @@
-#' Select variables
+#' Select or rename variables
 #'
-#' These functions power [dplyr::select()] and [dplyr::rename()].
+#' These functions power [dplyr::select()] and [dplyr::rename()]. They
+#' enable dplyr selecting or renaming semantics in your own functions.
 #'
-#' For historic reasons, the `vars` and `include` arguments are not
-#' prefixed with `.`. This means that any argument starting with `v`
-#' might partial-match on `vars` if it is not explicitly named. Also
-#' `...` cannot accept arguments named `exclude` or `include`. You can
-#' enquose and splice the dots to work around these limitations (see
-#' examples).
+#' @section Context of evaluation:
+#'
+#' Quoting verbs usually support references to both objects from the
+#' data frame and objects from the calling context. Selecting verbs
+#' behave a bit differently.
+#'
+#' * Bare names are evaluated in the data frame only. You cannot refer
+#'   to local objects unless you explicitly unquote them with `!!`.
+#'
+#' * Calls to helper functions are evaluated in the calling context
+#'   only. You can safely and directly refer to local objects.
 #'
 #' @param .vars A character vector of existing column names.
 #' @param ...,args Expressions to compute
@@ -58,9 +64,27 @@
 #' # Rename variables preserving all existing
 #' vars_rename(names(iris), petal_length = Petal.Length)
 #'
-#' # You can unquote names or formulas (or lists of)
-#' vars_select(names(iris), !!! list(quo(Petal.Length)))
+#' # You can unquote symbols or quosures
 #' vars_select(names(iris), !! quote(Petal.Length))
+#'
+#' # And unquote-splice lists of symbols or quosures
+#' vars_select(names(iris), !!! list(quo(Petal.Length), quote(Petal.Width)))
+#'
+#'
+#' # When selecting with bare symbols, you can only refer to data
+#' # objects. This avoids ambiguity. If you want to refer to local
+#' # objects, you can explicitly unquote them. They must contain
+#' # variable positions (integers) or variable names (strings):
+#' Species <- 2
+#' vars_select(names(iris), Species)     # Picks up `Species` from the data frame
+#' vars_select(names(iris), !! Species)  # Picks up the local object referring to column 2
+#'
+#' # On the other hand, function calls behave the opposite way. They
+#' # are evaluated in the local context only and cannot refer to data
+#' # frame objects. This makes it easy to refer to local variables:
+#' x <- "Petal"
+#' vars_select(names(iris), starts_with(x))  # Picks up the local variable `x`
+#'
 #'
 #' # The .data pronoun is available:
 #' vars_select(names(mtcars), .data$cyl)

--- a/man/vars_select.Rd
+++ b/man/vars_select.Rd
@@ -3,7 +3,7 @@
 \name{vars_select}
 \alias{vars_select}
 \alias{vars_rename}
-\title{Select variables}
+\title{Select or rename variables}
 \usage{
 vars_select(.vars, ..., .include = character(), .exclude = character())
 
@@ -37,16 +37,23 @@ A named character vector. Values are existing column names,
 names are new names.
 }
 \description{
-These functions power \code{\link[dplyr:select]{dplyr::select()}} and \code{\link[dplyr:rename]{dplyr::rename()}}.
+These functions power \code{\link[dplyr:select]{dplyr::select()}} and \code{\link[dplyr:rename]{dplyr::rename()}}. They
+enable dplyr selecting or renaming semantics in your own functions.
 }
-\details{
-For historic reasons, the \code{vars} and \code{include} arguments are not
-prefixed with \code{.}. This means that any argument starting with \code{v}
-might partial-match on \code{vars} if it is not explicitly named. Also
-\code{...} cannot accept arguments named \code{exclude} or \code{include}. You can
-enquose and splice the dots to work around these limitations (see
-examples).
+\section{Context of evaluation}{
+
+
+Quoting verbs usually support references to both objects from the
+data frame and objects from the calling context. Selecting verbs
+behave a bit differently.
+\itemize{
+\item Bare names are evaluated in the data frame only. You cannot refer
+to local objects unless you explicitly unquote them with \code{!!}.
+\item Calls to helper functions are evaluated in the calling context
+only. You can safely and directly refer to local objects.
 }
+}
+
 \examples{
 # Keep variables
 vars_select(names(iris), everything())
@@ -75,9 +82,27 @@ vars_select(names(iris), petal = starts_with("Petal"))
 # Rename variables preserving all existing
 vars_rename(names(iris), petal_length = Petal.Length)
 
-# You can unquote names or formulas (or lists of)
-vars_select(names(iris), !!! list(quo(Petal.Length)))
+# You can unquote symbols or quosures
 vars_select(names(iris), !! quote(Petal.Length))
+
+# And unquote-splice lists of symbols or quosures
+vars_select(names(iris), !!! list(quo(Petal.Length), quote(Petal.Width)))
+
+
+# When selecting with bare symbols, you can only refer to data
+# objects. This avoids ambiguity. If you want to refer to local
+# objects, you can explicitly unquote them. They must contain
+# variable positions (integers) or variable names (strings):
+Species <- 2
+vars_select(names(iris), Species)     # Picks up `Species` from the data frame
+vars_select(names(iris), !! Species)  # Picks up the local object referring to column 2
+
+# On the other hand, function calls behave the opposite way. They
+# are evaluated in the local context only and cannot refer to data
+# frame objects. This makes it easy to refer to local variables:
+x <- "Petal"
+vars_select(names(iris), starts_with(x))  # Picks up the local variable `x`
+
 
 # The .data pronoun is available:
 vars_select(names(mtcars), .data$cyl)

--- a/tests/testthat/test-select-vars.R
+++ b/tests/testthat/test-select-vars.R
@@ -28,3 +28,8 @@ test_that("abort on unknown columns", {
   expect_error(vars_select(letters, "foo"), "must match column names")
   expect_error(vars_select(letters, c("a", "bar", "foo", "d")), "bar, foo")
 })
+
+test_that("symbol overscope is isolated from context", {
+  foo <- 10
+  expect_error(vars_select(letters, foo), "object 'foo' not found")
+})

--- a/tests/testthat/test-select-vars.R
+++ b/tests/testthat/test-select-vars.R
@@ -33,3 +33,7 @@ test_that("symbol overscope is isolated from context", {
   foo <- 10
   expect_error(vars_select(letters, foo), "object 'foo' not found")
 })
+
+test_that("can select with unnamed elements", {
+  expect_identical(vars_select(c("a", ""), a), c(a = "a"))
+})

--- a/tests/testthat/test-select-vars.R
+++ b/tests/testthat/test-select-vars.R
@@ -32,6 +32,12 @@ test_that("abort on unknown columns", {
 test_that("symbol overscope is isolated from context", {
   foo <- 10
   expect_error(vars_select(letters, foo), "object 'foo' not found")
+  expect_error(vars_select(letters, ((foo))), "object 'foo' not found")
+})
+
+test_that("symbol overscope works with parenthesised expressions", {
+  expect_identical(vars_select(letters, ((((a)):((w))))), vars_select(letters, a:w))
+  expect_identical(vars_select(letters, -((((a)):((y))))), c(z = "z"))
 })
 
 test_that("can select with unnamed elements", {


### PR DESCRIPTION
Includes #12 

Symbols and symbol helpers like `:` and `c()` are now evaluated in the data context only. This addresses https://github.com/tidyverse/dplyr/issues/2904