### PR TITLE
Handle strings in `:` expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,8 +55,8 @@ vars_select(names(mtcars), .data$cyl : .data$drat)
 
 ## New features
 
-* `:` now handles strings as well. This makes it easy to unquote a
-  column name: `(!! name) : last_var()`.
+* `:` and `-` now handle strings as well. This makes it easy to
+  unquote a column name: `(!! name) : last_var()` or `-(!! name)`.
 
 * `vars_select()` gains a `.strict` argument similar to
   `rename_vars()`.  If set to `FALSE`, errors about unknown variables

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,9 @@ vars_select(names(mtcars), .data$cyl : .data$drat)
 
 ## New features
 
+* `:` now handles strings as well. This makes it easy to unquote a
+  column name: `(!! name) : last_var()`.
+
 * `vars_select()` gains a `.strict` argument similar to
   `rename_vars()`.  If set to `FALSE`, errors about unknown variables
   are ignored.

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,6 +47,7 @@ minus_sym <- quote(`-`)
 colon_sym <- quote(`:`)
 c_sym <- quote(`c`)
 
+is_language <- is_lang
 quo_is_language <- function(quo, name = NULL, n = NULL, ns = NULL) {
-  is_lang(f_rhs(quo), name = name, n = n, ns = ns)
+  is_language(f_rhs(quo), name = name, n = n, ns = ns)
 }

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -169,7 +169,7 @@ vars_select <- function(.vars, ...,
 }
 
 ignore_unknown_symbols <- function(vars, quos) {
-  quos <- discard(quos, is_unknown_symbol, vars)
+  quos <- discard(quos, is_ignored, vars)
   quos <- map_if(quos, is_concat_lang, lang_ignore_unknown_symbols, vars)
   quos
 }
@@ -181,6 +181,19 @@ lang_ignore_unknown_symbols <- function(quo, vars) {
   expr <- lang(node_car(expr), !!! args)
 
   set_expr(quo, expr)
+}
+
+is_ignored <- function(quo, vars) {
+  is_unknown_symbol(quo, vars) || is_ignored_minus_lang(quo, vars)
+}
+is_ignored_minus_lang <- function(quo, vars) {
+  expr <- get_expr(quo)
+
+  if (!is_language(expr, quote(`-`), 1L)) {
+    return(FALSE)
+  }
+
+  is_unknown_symbol(node_cadr(expr), vars)
 }
 is_unknown_symbol <- function(quo, vars) {
   expr <- get_expr(quo)

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -201,6 +201,7 @@ vars_select_eval <- function(vars, quos) {
   # Symbols and calls to `:` and `c()` are evaluated with data in scope
   is_helper <- map_lgl(quos, quo_is_helper)
   data <- set_names(as.list(seq_along(vars)), vars)
+  data <- c(data, `:` = vars_colon)
   ind_list <- map_if(quos, !is_helper, eval_tidy, data)
 
   # All other calls are evaluated in the context only
@@ -208,6 +209,27 @@ vars_select_eval <- function(vars, quos) {
   ind_list <- map_if(ind_list, is_helper, eval_tidy)
 
   ind_list
+}
+
+vars_colon <- function(x, y) {
+  if (is_string(x)) {
+    x <- match_string(x)
+  }
+  if (is_string(y)) {
+    y <- match_string(y)
+  }
+
+  x:y
+}
+match_string <- function(x) {
+  vars <- peek_vars()
+  out <- match(x, vars)
+
+  if (is_na(out)) {
+    abort(glue("Unknown { singular(vars) } `{ x }`"))
+  }
+
+  out
 }
 
 extract_expr <- function(expr) {

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -201,7 +201,10 @@ vars_select_eval <- function(vars, quos) {
   # Symbols and calls to `:` and `c()` are evaluated with data in scope
   is_helper <- map_lgl(quos, quo_is_helper)
   data <- set_names(as.list(seq_along(vars)), vars)
-  data <- c(data, `:` = vars_colon)
+
+  # Overscope `:` and `-` with versions that handle strings
+  data <- c(data, `:` = vars_colon, `-` = vars_minus)
+
   ind_list <- map_if(quos, !is_helper, eval_tidy, data)
 
   # All other calls are evaluated in the context only
@@ -220,6 +223,17 @@ vars_colon <- function(x, y) {
   }
 
   x:y
+}
+vars_minus <- function(x, y) {
+  if (!missing(y)) {
+    return(x - y)
+  }
+
+  if (is_string(x)) {
+    x <- match_string(x)
+  }
+
+  -x
 }
 match_string <- function(x) {
   vars <- peek_vars()

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -185,7 +185,7 @@ lang_ignore_unknown_symbols <- function(quo, vars) {
 is_unknown_symbol <- function(quo, vars) {
   expr <- get_expr(quo)
 
-  if (!is_symbol(expr)) {
+  if (!is_symbol(expr) && !is_string(expr)) {
     return(FALSE)
   }
 

--- a/tests/testthat/test-vars-rename.R
+++ b/tests/testthat/test-vars-rename.R
@@ -22,6 +22,17 @@ test_that("when .strict = FALSE, vars_rename always succeeds", {
     vars_rename("x", A = x, B = y, .strict = FALSE),
     c(A = "x")
   )
+
+  expect_error(
+    vars_rename(c("a", "b"), d = "e", f = "g", .strict = TRUE),
+    "Unknown columns `e` and `g`",
+    fixed = TRUE
+  )
+
+  expect_identical(
+    vars_rename("x", A = "x", B = "y", .strict = FALSE),
+    c(A = "x")
+  )
 })
 
 test_that("vars_rename() works with positions", {

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -68,3 +68,8 @@ test_that("unknown variables errors are ignored if `.strict` is FALSE", {
   expect_identical(vars_select(letters, a, `_foo`, .strict = FALSE), c(a = "a"))
   expect_identical(vars_select(letters, c(a, `_foo`, c), .strict = FALSE), c(a = "a", c = "c"))
 })
+
+test_that("`:` handles strings", {
+  expect_identical(vars_select(letters, "b":"d"), vars_select(letters, b:d))
+  expect_error(vars_select(letters, "b":"Z"), "Unknown column `Z`")
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -67,6 +67,10 @@ test_that("unknown variables errors are ignored if `.strict` is FALSE", {
   expect_identical(vars_select(letters, `_foo`, .strict = FALSE), set_names(chr()))
   expect_identical(vars_select(letters, a, `_foo`, .strict = FALSE), c(a = "a"))
   expect_identical(vars_select(letters, a, "_foo", .strict = FALSE), c(a = "a"))
+
+  expect_identical(vars_select(letters, a, -`_foo`, .strict = FALSE), c(a = "a"))
+  expect_identical(vars_select(letters, a, -"`_foo`", .strict = FALSE), c(a = "a"))
+
   expect_identical(vars_select(letters, c(a, `_foo`, c), .strict = FALSE), c(a = "a", c = "c"))
   expect_identical(vars_select(letters, c(a, "_foo", c), .strict = FALSE), c(a = "a", c = "c"))
 })

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -75,3 +75,11 @@ test_that("`:` handles strings", {
   expect_identical(vars_select(letters, "b":"d"), vars_select(letters, b:d))
   expect_error(vars_select(letters, "b":"Z"), "Unknown column `Z`")
 })
+
+test_that("`-` handles strings", {
+  expect_identical(vars_select(letters, -"c"), vars_select(letters, -c))
+})
+
+test_that("`-` handles positions", {
+  expect_identical(vars_select(letters, 10 - 7), vars_select(letters, 3))
+})

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -66,7 +66,9 @@ test_that("can supply empty inputs", {
 test_that("unknown variables errors are ignored if `.strict` is FALSE", {
   expect_identical(vars_select(letters, `_foo`, .strict = FALSE), set_names(chr()))
   expect_identical(vars_select(letters, a, `_foo`, .strict = FALSE), c(a = "a"))
+  expect_identical(vars_select(letters, a, "_foo", .strict = FALSE), c(a = "a"))
   expect_identical(vars_select(letters, c(a, `_foo`, c), .strict = FALSE), c(a = "a", c = "c"))
+  expect_identical(vars_select(letters, c(a, "_foo", c), .strict = FALSE), c(a = "a", c = "c"))
 })
 
 test_that("`:` handles strings", {


### PR DESCRIPTION
Also fixes a bug with strings when `.strict` is `FALSE`