### PR TITLE
Fix issues with last_col()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
   vars_select(names(mtcars), - (!! vars))
   ```
 
+* `last_col()` now issues an error when the variable vector is empty.
+
 
 # tidyselect 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 
 * `last_col()` now issues an error when the variable vector is empty.
 
+* `last_col()` now returns column positions rather than column names
+  for consistency with other helpers. This also makes it compatible
+  with functions like `seq()`.
+
 
 # tidyselect 0.2.0
 

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -127,7 +127,7 @@ last_col <- function(offset = 0, vars = peek_vars()) {
   if (offset && n <= offset) {
     abort(glue("`offset` must be smaller than the number of { plural(vars) }"))
   } else if (n == 0) {
-    vars
+    abort(glue("Can't select last { singular(vars) } when input is empty"))
   } else {
     vars[[n - offset]]
   }

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -125,7 +125,7 @@ last_col <- function(offset = 0, vars = peek_vars()) {
   n <- length(vars)
 
   if (offset && n <= offset) {
-    abort("`offset` must be smaller than the number of variables")
+    abort(glue("`offset` must be smaller than the number of { plural(vars) }"))
   } else if (n == 0) {
     vars
   } else {

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -120,7 +120,7 @@ everything <- function(vars = peek_vars()) {
 #' @export
 #' @param offset Set it to `n` to select the nth var from the end.
 #' @rdname select_helpers
-last_col <- function(offset = 0, vars = peek_vars()) {
+last_col <- function(offset = 0L, vars = peek_vars()) {
   stopifnot(is_integerish(offset))
   n <- length(vars)
 
@@ -129,7 +129,7 @@ last_col <- function(offset = 0, vars = peek_vars()) {
   } else if (n == 0) {
     abort(glue("Can't select last { singular(vars) } when input is empty"))
   } else {
-    vars[[n - offset]]
+    n - as.integer(offset)
   }
 }
 

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -226,6 +226,6 @@ test_that("last_col() selects last argument with offset", {
   expect_identical(last_col(0, vars), "c")
   expect_identical(last_col(2, vars), "a")
 
-  expect_error(last_col(3, vars), "`offset` must be smaller")
   expect_identical(last_col(vars = chr()), chr())
+  expect_error(last_col(3, vars), "`offset` must be smaller than the number of columns")
 })

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -226,6 +226,6 @@ test_that("last_col() selects last argument with offset", {
   expect_identical(last_col(0, vars), "c")
   expect_identical(last_col(2, vars), "a")
 
-  expect_identical(last_col(vars = chr()), chr())
   expect_error(last_col(3, vars), "`offset` must be smaller than the number of columns")
+  expect_error(last_col(vars = chr()), "Can't select last column when input is empty")
 })

--- a/tests/testthat/test-select-helpers.R
+++ b/tests/testthat/test-select-helpers.R
@@ -223,8 +223,8 @@ test_that("can select with .data pronoun (#2715)", {
 
 test_that("last_col() selects last argument with offset", {
   vars <- letters[1:3]
-  expect_identical(last_col(0, vars), "c")
-  expect_identical(last_col(2, vars), "a")
+  expect_identical(last_col(0, vars), 3L)
+  expect_identical(last_col(2, vars), 1L)
 
   expect_error(last_col(3, vars), "`offset` must be smaller than the number of columns")
   expect_error(last_col(vars = chr()), "Can't select last column when input is empty")


### PR DESCRIPTION
* Issue an error when the variable vector is empty.

* Return column positions rather than column names for consistency with other helpers. This also makes it compatible with functions like `seq()`.