### PR TITLE
`c()` handles strings like `:` and `-` - fixes #37

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 
 # tidyselect 0.2.0.9000
+* `c()` now supports character vectors the same way as `-` and `seq()`.
+  (#37 @gergness)
 
 * `-` now supports character vectors in addition to strings. This
   makes it easy to unquote column names to exclude from the set:

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -217,6 +217,9 @@ vars_select_eval <- function(vars, quos) {
 
   # Overscope `:` and `-` with versions that handle strings
   data <- c(data, `:` = vars_colon, `-` = vars_minus)
+  # If there's no variable called c, overscope `c()` with a version
+  # that handles strings
+  if (!("c" %in% names(data))) data <- c(data, `c` = vars_c)
 
   ind_list <- map_if(quos, !is_helper, eval_tidy, data)
 
@@ -247,6 +250,16 @@ vars_minus <- function(x, y) {
   }
 
   -x
+}
+vars_c <- function(...) {
+  dots <- list(...)
+  dots <- lapply(dots, function(x) {
+    if (is_character(x)) {
+      x <- match_strings(x)
+    }
+    x
+  })
+  do.call(`c`, dots)
 }
 match_strings <- function(x) {
   vars <- peek_vars()


### PR DESCRIPTION
Tried fixing it myself to see what it would look like - I can see why you're nervous about this @lionel- , the tests caught problems when a variable is named "c". 

I fixed by not adding the extra function to the overscope if there was a variable named c, but I think it could be improved.
