### PR TITLE
typos in select helpers

### DIFF
--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -1,10 +1,10 @@
 #' Select helpers
 #'
 #' These functions allow you to select variables based on their names.
-#' * `starts_with()`: starts with a prefix
-#' * `ends_with()`: ends with a prefix
-#' * `contains()`: contains a literal string
-#' * `matches()`: matches a regular expression
+#' * `starts_with()`: starts with a prefix.
+#' * `ends_with()`: ends with a suffix.
+#' * `contains()`: contains a literal string.
+#' * `matches()`: matches a regular expression.
 #' * `num_range()`: a numerical range like x01, x02, x03.
 #' * `one_of()`: variables in character vector.
 #' * `everything()`: all variables.
@@ -82,7 +82,7 @@ matches <- function(match, ignore.case = TRUE, vars = peek_vars()) {
 #' @export
 #' @rdname select_helpers
 #' @param prefix A prefix that starts the numeric range.
-#' @param range A sequence of integers, like `1:5`
+#' @param range A sequence of integers, like `1:5`.
 #' @param width Optionally, the "width" of the numeric range. For example,
 #'   a range of 2 gives "01", a range of three "001", etc.
 num_range <- function(prefix, range, width = NULL, vars = peek_vars()) {

--- a/man/select_helpers.Rd
+++ b/man/select_helpers.Rd
@@ -40,7 +40,7 @@ automatically set to the names of the table.}
 
 \item{prefix}{A prefix that starts the numeric range.}
 
-\item{range}{A sequence of integers, like \code{1:5}}
+\item{range}{A sequence of integers, like \code{1:5}.}
 
 \item{width}{Optionally, the "width" of the numeric range. For example,
 a range of 2 gives "01", a range of three "001", etc.}
@@ -55,10 +55,10 @@ An integer vector giving the position of the matched variables.
 \description{
 These functions allow you to select variables based on their names.
 \itemize{
-\item \code{starts_with()}: starts with a prefix
-\item \code{ends_with()}: ends with a prefix
-\item \code{contains()}: contains a literal string
-\item \code{matches()}: matches a regular expression
+\item \code{starts_with()}: starts with a prefix.
+\item \code{ends_with()}: ends with a suffix.
+\item \code{contains()}: contains a literal string.
+\item \code{matches()}: matches a regular expression.
 \item \code{num_range()}: a numerical range like x01, x02, x03.
 \item \code{one_of()}: variables in character vector.
 \item \code{everything()}: all variables.


### PR DESCRIPTION
- "`ends_with()`: ends with a suffix." (not "with a prefix")
- add "." where missing