### PR TITLE
handle empty names gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .RData
 revdep/checks
 revdep/library
+*.o
+*.so
+issues

--- a/R/vars-select.R
+++ b/R/vars-select.R
@@ -220,7 +220,8 @@ vars_select_eval <- function(vars, quos) {
 
   # Symbols and calls to `:` and `c()` are evaluated with data in scope
   is_helper <- map_lgl(quos, quo_is_helper)
-  data <- set_names(as.list(seq_along(vars)), vars)
+  are_name <- are_name(vars)
+  data <- set_names(as.list(seq_along(vars)), vars)[!are_name]
   overscope <- env_bury(overscope_top, !!! data)
 
   overscope <- new_overscope(overscope, overscope_top)

--- a/R/vars.R
+++ b/R/vars.R
@@ -116,14 +116,14 @@ vars_validate <- function(vars) {
     abort("`vars` must be a character vector")
   }
 
-  are_name <- are_name(vars)
-  if (any(!are_name)) {
-    # Propagate `type` attribute when subsetting. A proper S3 class
-    # might be better.
-    type <- attr(vars, "type")
-    vars <- vars[!are_name]
-    attr(vars, "type") <- type
-  }
+  # are_name <- are_name(vars)
+  # if (any(!are_name)) {
+  #   # Propagate `type` attribute when subsetting. A proper S3 class
+  #   # might be better.
+  #   type <- attr(vars, "type")
+  #   vars <- vars[!are_name]
+  #   attr(vars, "type") <- type
+  # }
 
   vars
 }

--- a/R/vars.R
+++ b/R/vars.R
@@ -116,15 +116,6 @@ vars_validate <- function(vars) {
     abort("`vars` must be a character vector")
   }
 
-  # are_name <- are_name(vars)
-  # if (any(!are_name)) {
-  #   # Propagate `type` attribute when subsetting. A proper S3 class
-  #   # might be better.
-  #   type <- attr(vars, "type")
-  #   vars <- vars[!are_name]
-  #   attr(vars, "type") <- type
-  # }
-
   vars
 }
 

--- a/tests/testthat/test-vars-select.R
+++ b/tests/testthat/test-vars-select.R
@@ -43,6 +43,8 @@ test_that("symbol overscope works with parenthesised expressions", {
 test_that("can select with unnamed elements", {
   expect_identical(vars_select(c("a", ""), a), c(a = "a"))
   expect_identical(vars_select(c("a", NA), a), c(a = "a"))
+  expect_identical(vars_select(c("", "a"), a), c(a = "a"))
+  expect_identical(vars_select(c(NA, "a"), a), c(a = "a"))
 })
 
 test_that("can customise error messages", {

--- a/tests/testthat/test-vars.R
+++ b/tests/testthat/test-vars.R
@@ -32,11 +32,16 @@ test_that("has_vars() detects variables", {
   expect_true(has_vars())
 })
 
-test_that("Missing names are ignored", {
-  skip("let's discuss this")
+test_that("Missing names are kept", {
   scoped_vars(c("foo", NA))
-  expect_identical(peek_vars(), "foo")
+  expect_identical(peek_vars(), c("foo", NA))
+
+  scoped_vars(c(NA, "foo"))
+  expect_identical(peek_vars(), c(NA, "foo"))
 
   scoped_vars(c("bar", ""))
-  expect_identical(peek_vars(), "bar")
+  expect_identical(peek_vars(), c("bar", ""))
+
+  scoped_vars(c("", "bar"))
+  expect_identical(peek_vars(), c("", "bar"))
 })

--- a/tests/testthat/test-vars.R
+++ b/tests/testthat/test-vars.R
@@ -33,6 +33,7 @@ test_that("has_vars() detects variables", {
 })
 
 test_that("Missing names are ignored", {
+  skip("let's discuss this")
   scoped_vars(c("foo", NA))
   expect_identical(peek_vars(), "foo")
 


### PR DESCRIPTION
Related to #61. 

This PR is meant as a conversation starter, and is not ready to be merged. 

What I've done is to let NA and "" through in `peek_vars()` but ignore them when feeding the overscope: 

```r
  # Symbols and calls to `:` and `c()` are evaluated with data in scope
  is_helper <- map_lgl(quos, quo_is_helper)
  are_name <- are_name(vars)
  data <- set_names(as.list(seq_along(vars)), vars)[!are_name]
  overscope <- env_bury(overscope_top, !!! data)
```

so this works: 

```r
> vars_select(c("", "a"), a)
  a 
"a" 
> vars_select(c(NA, "a"), a)
  a 
"a" 
```

But then this one I had to skip: 

```r
test_that("Missing names are ignored", {
  skip("let's discuss this")
  scoped_vars(c("foo", NA))
  expect_identical(peek_vars(), "foo")

  scoped_vars(c("bar", ""))
  expect_identical(peek_vars(), "bar")
})
```

not sure how much `peek_vars` is an implementation detail, and this is potentially dangerous. The other tests don't care. 

