### PR TITLE
vars_select() skips all zero vectors. closes #82

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 # tidyselect 0.2.5.9000
 
+* `vars_select()` ignores vectors with only zeros (#82). 
 
 # tidyselect 0.2.5
 

--- a/src/combine_variables.cpp
+++ b/src/combine_variables.cpp
@@ -22,6 +22,10 @@ int vector_sign(IntegerVector x) {
   }
 }
 
+bool all_zero(const IntegerVector& x) {
+  return x.size() > 0 && all(x == 0).is_true();
+}
+
 class VarList {
 
   std::vector<int> out_indx;
@@ -90,8 +94,16 @@ SEXP inds_combine(CharacterVector vars, ListOf<IntegerVector> xs) {
     xs_names = raw_names;
   }
 
+  // Find the first vector that is not all zero
+  int first = 0;
+  for (; first < xs.size(); first++) {
+    if (!all_zero(xs[first])) break;
+  }
+  // If all vectors are all zero, nothing to do
+  if (first == xs.size()) return selected;
+
   // If first component is negative, pre-fill with existing vars
-  if (vector_sign(xs[0]) == -1) {
+  if (vector_sign(xs[first]) == -1) {
     for (int j = 0; j < vars.size(); ++j) {
       selected.add(j + 1, vars[j]);
     }
@@ -100,6 +112,8 @@ SEXP inds_combine(CharacterVector vars, ListOf<IntegerVector> xs) {
   for (int i = 0; i < xs.size(); ++i) {
     IntegerVector x = xs[i];
     if (x.size() == 0) continue;
+    // skip if all zero
+    if (all_zero(x)) continue;
 
     int sign = vector_sign(x);
 

--- a/src/combine_variables.cpp
+++ b/src/combine_variables.cpp
@@ -97,10 +97,14 @@ SEXP inds_combine(CharacterVector vars, ListOf<IntegerVector> xs) {
   // Find the first vector that is not all zero
   int first = 0;
   for (; first < xs.size(); first++) {
-    if (!all_zero(xs[first])) break;
+    if (!all_zero(xs[first])) {
+      break;
+    }
   }
   // If all vectors are all zero, nothing to do
-  if (first == xs.size()) return selected;
+  if (first == xs.size()) {
+    return selected;
+  }
 
   // If first component is negative, pre-fill with existing vars
   if (vector_sign(xs[first]) == -1) {
@@ -111,10 +115,10 @@ SEXP inds_combine(CharacterVector vars, ListOf<IntegerVector> xs) {
 
   for (int i = 0; i < xs.size(); ++i) {
     IntegerVector x = xs[i];
-    if (x.size() == 0) continue;
-    // skip if all zero
-    if (all_zero(x)) continue;
-
+    // skip if empty or all zero
+    if (x.size() == 0 || all_zero(x)) {
+      continue;
+    }
     int sign = vector_sign(x);
 
     if (sign == 0)

--- a/tests/testthat/test-inds-combine.R
+++ b/tests/testthat/test-inds-combine.R
@@ -40,12 +40,19 @@ test_that("if one name for multiple vars, use integer index", {
   expect_equal(inds_combine(letters[1:3], list(x = 1:3)), c(x1 = 1, x2 = 2, x3 = 3))
 })
 
-test_that("invalid inputs raise error", {
-  expect_error(
-    inds_combine(names(mtcars), list(0)),
-    "Each argument must yield either positive or negative integers",
-    fixed = TRUE
+test_that("select(0) corner case #82", {
+  expect_equal(inds_combine(names(mtcars), 0), set_names(integer(), character()))
+  expect_equal(
+    inds_combine(names(mtcars), list(0, 1:3)),
+    inds_combine(names(mtcars), list(1:3))
   )
+  expect_equal(
+    inds_combine(names(mtcars), list(0, -(1:3))),
+    inds_combine(names(mtcars), list(-(1:3)))
+  )
+})
+
+test_that("invalid inputs raise error", {
   expect_error(
     inds_combine(names(mtcars), list(c(-1, 1))),
     "Each argument must yield either positive or negative integers",


### PR DESCRIPTION
``` r
library(tidyselect)

vars_select(letters, 0)
#> named character(0)
vars_select(letters, 0, 1:2)
#>   a   b 
#> "a" "b"
vars_select(letters, 0, -(1:24))
#>   y   z 
#> "y" "z"
```

The idea is to skip all zero vectors, for #82