### PR TITLE
Bump minimum R version to 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: packages
 
 matrix:
   include:
-    - r: 3.1
+    - r: 3.2
     - r: oldrel
     - r: release
       env: R_CODECOV=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: A backend for the selecting functions of the 'tidyverse'.
     packages in a way that is consistent with other 'tidyverse'
     interfaces for selection.
 Depends:
-    R (>= 3.1)
+    R (>= 3.2)
 Imports:
     glue (>= 1.3.0),
     purrr,


### PR DESCRIPTION
This PR fixe failure in Travis CI.

Tidyverse packages are going to support only R 3.2 or greater, and the suggested dplyr package on CRAN is already doing so.
Thus, I bumped minimum R version to 3.2 in DESCRIPTION and .travis.yml.
